### PR TITLE
betting, shuffle/deal implementation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,8 @@ io.on("connection", socket => {
   socket.on("rqst_ingame_state", () => Lobby.getState(socket));
 
   // room server sockets
-  socket.on("srqst_ingame_place_bet", data => Lobby.bet(data, socket, io));
+  socket.on("sresp_ingame_place_bet", data => Lobby.bet(data, socket, io));
+  socket.on("sresp_ingame_deal", () => Lobby.confirm("deal", socket, io));
 });
 
 http.listen(8080, () => console.log("server started"));

--- a/src/libraries/lobby.js
+++ b/src/libraries/lobby.js
@@ -132,8 +132,16 @@ class Lobby {
     let user = Users.getUser(socket.id);
     if (user && user.room) {
       let room = this.findRoom(user.room);
-      this.rooms[room].bet(data, user, socket, io);
+      this.rooms[room].bet(data, user, io);
       return;
+    }
+  }
+
+  confirm(anim, socket, io) {
+    let user = Users.getUser(socket.id);
+    if (user && user.room) {
+      let room = this.findRoom(user.room);
+      this.rooms[room].confirm(anim, user, io);
     }
   }
 

--- a/src/libraries/room/components/player.js
+++ b/src/libraries/room/components/player.js
@@ -12,7 +12,8 @@ class Player {
     this.isReady = false;
     this.isPlaying = false;
     this.cards = [];
-    this.bet = -1;
+    this.bet = 0;
+    this.lastConfirmedAnimation = "";
   }
 }
 

--- a/src/utils/convention.json
+++ b/src/utils/convention.json
@@ -1,9 +1,4 @@
-{
-  state = [
-    "waiting", "playerphase", "bankerphase", "ended"
-  ]
-}
-
+// in game state
 {
   "roomnumber": 5040,
   "players": [
@@ -11,28 +6,57 @@
       "sid": 5,
       "nickname": "test",
       "balance": 10000,
+      "bet": 5000
       "imgnumber": 4,
       "gender": 0,
       "isReady": false,
       "isPlaying": false,
-      "cards": [{ "img":"spade", "num": 'A' }, null, null],
+      "cards": [{ "img":"spade", "num": 'A' }],
+      "win": 0,
+      "loss": 0,
+      "seatIndex": 1,
     },
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null
+    {
+      "sid": 6,
+      "nickname": "test1",
+      "balance": 10000,
+      "bet": 5000
+      "imgnumber": 4,
+      "gender": 0,
+      "isReady": false,
+      "isPlaying": false,
+      "cards": [{"img": "hidden" }, {"img": "hidden" }],
+      "win": 0,
+      "loss": 0,
+      "seatIndex": 2
+    },
   ],
   "bankerIndex": 0,
-  "turnIndex": 0, // next players index
-  "phaseIndex": 0, // server action counter
+  "phaseIndex": 0,
   "minimumBank": 30000,
+  "minBet": 1000,
+  "maxBet":2000,
   "bank": 30000, 
-  "status": 0,
-  "warning": -1, // -1: hasn't reached, 1: 1st round, ... 3: last round  
-  "gamesPlayed": 0,
-  "deck": [{ "img":"spade", "num": 'A' }, ...],
-  "houseProfit": 0.0
+  "warning": -1
 }
+
+// lobby room
+{
+  "retcode": 0,
+  "roomlist": [
+    {
+      "roomnumber": 1001,
+      "players": 5,
+      "bank": 3000,
+      "status": "player phase"
+    },
+    {
+      "roomnumber": 1002,
+      "players": 1,
+      "bank": 3000,
+      "status": "waiting"
+    },
+    ...
+  ]
+}
+


### PR DESCRIPTION
new protocols
---
client side
- sresp_ingame_place_bet
   - payload: betAmount: 1000
- sresp_ingame_deal
   - payload: none
   - should be sent after deal animation is complete
---
server side
- resp_ingame_imready (response to rqst_ingame_imready) (to client)
   - payload: retcode: 0 on success
- srqst_ingame_gamestart (to room)
   - once all players ready
   - payload: timestamp: 12313123
       - actual timestamp is not yet implemented
- srqst_ingame_place_bet (to room)
   - payload: 
      - sid: 123
      - betAmount: 1000
      - ts: 123123123
      - players
         - sid, cards
- srqst_ingame_deal (to client)
   - once all bets are confirmed
   - payload:
      - cards
- srqst_ingame_player_action (to room)
   - payload: none
---

